### PR TITLE
Build errors from clean git-clone

### DIFF
--- a/src/types/handle.h
+++ b/src/types/handle.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "common_headers.h"
+#include "type.h"
 
 namespace circa {
 namespace handle_t {

--- a/src/weak_ptrs.h
+++ b/src/weak_ptrs.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include <cstddef>
+
 namespace circa {
 
 typedef size_t WeakPtr;


### PR DESCRIPTION
I was getting some errors building from the latest git revision on my Archlinux setup with typical development libraries, mostly due to #include problems. I've fixed the two problems following the build directions in your README and I was able to get circa to build cleanly.
